### PR TITLE
Feature : Metrics for specific process

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,27 @@ const PROCESS_GPU_MEMORY_USAGE: &str = "process.gpu.memory.usage";
 pub fn init_process_observer(meter: Meter) -> Result<()> {
     let pid =
         get_current_pid().map_err(|err| eyre::eyre!("could not get current pid. Error: {err}"))?;
+    register_metrics(meter, pid)
+}
+
+/// Record asynchronously information about a specific process by its PID.
+/// # Example
+///
+/// ```
+/// use opentelemetry::global;
+/// use opentelemetry_system_metrics::init_process_observer_for_pid;
+///
+/// let meter = global::meter("process-meter");
+/// let pid = 1234; // replace with the actual PID
+/// init_process_observer_for_pid(meter, pid);
+/// ```
+///
+pub fn init_process_observer_for_pid(meter: Meter, pid: u32) -> Result<()> {
+    let pid = sysinfo::Pid::from_u32(pid);
+    register_metrics(meter, pid)
+}
+
+fn register_metrics(meter: Meter, pid: sysinfo::Pid) -> Result<()> {
     let sys_ = System::new_all();
     let core_count = sys_
         .physical_core_count()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,17 +55,17 @@ const DIRECTION: Key = Key::from_static_str("direction");
 // const PROCESS_GPU_USAGE: &str = "process.gpu.usage";
 const PROCESS_GPU_MEMORY_USAGE: &str = "process.gpu.memory.usage";
 
-// Record asynchronnously information about the current process.
-// # Example
-//
-// ```
-// use opentelemetry::global;
-// use opentelemetry_system_metrics::init_process_observer;
-//
-// let meter = global::meter("process-meter");
-// init_process_observer(meter);
-// ```
-//
+/// Record asynchronnously information about the current process.
+/// # Example
+///
+/// ```
+/// use opentelemetry::global;
+/// use opentelemetry_system_metrics::init_process_observer;
+///
+/// let meter = global::meter("process-meter");
+/// init_process_observer(meter);
+/// ```
+///
 pub fn init_process_observer(meter: Meter) -> Result<()> {
     let pid =
         get_current_pid().map_err(|err| eyre::eyre!("could not get current pid. Error: {err}"))?;


### PR DESCRIPTION
Hey, I've stumbled on your project which does exactly what I needed (so thank you :) ). I needed to monitor other processes aswell, so I've added another function in order to allow to monitor metrics for arbitrary PID (for example, child processes of the current process).

I've modified your base `init_process_observer` to be a simple wrapper with current PID around a new `register_metrics` function.

(Also, fixed the docstrings to fix the function doc on [doc.rs](https://docs.rs/opentelemetry-system-metrics/0.2.0/opentelemetry_system_metrics/fn.init_process_observer.html)

Best regards :)
`Green`.