### PR TITLE
Remove unused sysinfo monitor to enhance performance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,8 @@ async fn register_metrics(
         .with_unit("byte")
         .build();
 
-    let mut sys = System::new_all();
-    sys.refresh_all();
+    let mut sys = System::new();
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
 
     let common_attributes = if let Some(process) = sys.process(pid) {
         [


### PR DESCRIPTION
Related to https://github.com/dora-rs/dora/issues/970

`sysinfo` leaves a lot of file descriptors (`/proc/xxx/stat`) open when configured with `System::new_all()`. Use `System::new()` and `refresh_processes` instead reduces overhead. In general the number of opened fds reduced from ~4k to ~100 in a simple `dora run`.