### PR TITLE
Update OpenTelemetry dependencies to 0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 gpu = ["nvml-wrapper"]
 
 [dependencies]
-opentelemetry = { version = "0.31", features = ["metrics"] }
+opentelemetry = { version = "0.32", features = ["metrics"] }
 sysinfo = "0.35"
 nvml-wrapper = { version = "0.11.0", optional = true }
 eyre = "0.6.12"
@@ -26,14 +26,14 @@ tokio = { version = "1.44.2", features = [
 ] }
 
 [dev-dependencies]
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "metrics"] }
-opentelemetry-otlp = { version = "0.31", features = [
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "metrics"] }
+opentelemetry-otlp = { version = "0.32", features = [
     "tonic",
     "metrics",
     "grpc-tonic",
 ] }
 eyre = "0.6.12"
-opentelemetry-stdout = { version = "0.31", features = ["metrics"] }
+opentelemetry-stdout = { version = "0.32", features = ["metrics"] }
 
 [[example]]
 name = "otlp-tokio-metrics"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.24.0", features = ["abi3-py37"] }
 opentelemetry-system-metrics = { path = ".." }
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "metrics"] }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "metrics"] }
 futures = "0.3.12"
 tokio = { version = "1.44.2", features = [
     "rt",
@@ -20,9 +20,9 @@ tokio = { version = "1.44.2", features = [
     "time",
     "macros",
 ] }
-opentelemetry-otlp = { version = "0.31", features = [
+opentelemetry-otlp = { version = "0.32", features = [
     "tonic",
     "metrics",
     "grpc-tonic",
 ] }
-opentelemetry = { version = "0.31", features = ["metrics"] }
+opentelemetry = { version = "0.32", features = ["metrics"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! To use this crate, add the following to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! opentelemetry = "0.29"
+//! opentelemetry = "0.32"
 //! opentelemetry-system-metrics = "0.4"
 //! tokio = { version = "1", features = ["full"] }
 //! sysinfo = "0.34"


### PR DESCRIPTION
Bump opentelemetry, opentelemetry_sdk, opentelemetry-otlp, and
opentelemetry-stdout from 0.31 to 0.32 (sdk 0.32.1) in both the main
crate and the Python bindings. No source changes were required; the
metrics API used here is unchanged between 0.31 and 0.32.

Also update the stale opentelemetry version in the crate-level doc
example.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
